### PR TITLE
remove mentions of original `bevy_raylib` repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,7 @@ name = "bevy_raylib"
 version = "0.0.1"
 edition = "2021"
 license = "MIT OR Apache-2.0 OR Zlib"
-authors = ["ickk <crates@ickk.io>"]
 description = "A very simple Raylib plugin for Bevy"
-repository = "https://github.com/ickk/bevy_raylib"
-documentation = "https://docs.rs/bevy_raylib"
 readme = "README.md"
 
 [dependencies]

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,5 +1,3 @@
-Copyright (c) 2023 ickk
-
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
 the Software without restriction, including without limitation the rights to

--- a/LICENSE-ZLIB
+++ b/LICENSE-ZLIB
@@ -1,5 +1,3 @@
-Copyright (c) 2023 ickk
-
 This software is provided 'as-is', without any express or implied warranty. In
 no event will the authors be held liable for any damages arising from the use
 of this software.


### PR DESCRIPTION
removes mentions of the original repository

Feel free to also relicense as you see fit