### PR TITLE
feat: implement some `RaylibHandle` methods for `RaylibContext`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df7370d0e46b60e071917711d0860721f5347bc958bf325975ae6913a5dfcf01"
 
 [[package]]
-name = "bevy_raylib"
+name = "bevy_raylib2"
 version = "0.0.1"
 dependencies = [
  "bevy_app",

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,199 @@
+use raylib::core::error::Error;
+use raylib::prelude::*;
+
+pub struct RaylibContext {
+    pub rl: RaylibHandle,
+    pub(crate) thread: RaylibThread,
+}
+
+impl RaylibContext {
+    pub fn begin_drawing(&mut self) -> RaylibDrawHandle {
+        self.rl.begin_drawing(&self.thread)
+    }
+
+    pub fn draw(&mut self, func: impl FnMut(RaylibDrawHandle<'_>)) {
+        self.rl.draw(&self.thread, func)
+    }
+
+    pub fn load_image_from_screen(&self) -> Image {
+        self.rl.load_image_from_screen(&self.thread)
+    }
+
+    pub fn take_screenshot(&mut self, _: &RaylibThread, filename: &str) {
+        self.rl.take_screenshot(&self.thread, filename)
+    }
+
+    pub fn load_model(&mut self, _: &RaylibThread, filename: &str) -> Result<Model, Error> {
+        self.rl.load_model(&self.thread, filename)
+    }
+
+    pub fn load_model_from_mesh(
+        &mut self,
+        _: &RaylibThread,
+        mesh: WeakMesh,
+    ) -> Result<Model, Error> {
+        self.rl.load_model_from_mesh(&self.thread, mesh)
+    }
+
+    pub fn load_model_animations(
+        &mut self,
+        _: &RaylibThread,
+        filename: &str,
+    ) -> Result<Vec<ModelAnimation>, Error> {
+        self.rl.load_model_animations(&self.thread, filename)
+    }
+
+    pub fn update_model_animation(
+        &mut self,
+        _: &RaylibThread,
+        model: impl AsMut<raylib::ffi::Model>,
+        anim: impl AsRef<raylib::ffi::ModelAnimation>,
+        frame: i32,
+    ) {
+        self.rl
+            .update_model_animation(&self.thread, model, anim, frame)
+    }
+
+    pub fn update_model_animation_bones(
+        &mut self,
+        _: &RaylibThread,
+        model: impl AsMut<raylib::ffi::Model>,
+        anim: impl AsRef<raylib::ffi::ModelAnimation>,
+        frame: i32,
+    ) {
+        self.rl
+            .update_model_animation_bones(&self.thread, model, anim, frame)
+    }
+
+    pub fn load_material_default(&self, _: &RaylibThread) -> WeakMaterial {
+        self.rl.load_material_default(&self.thread)
+    }
+
+    pub fn unload_material(&mut self, _: &RaylibThread, material: WeakMaterial) {
+        unsafe { self.rl.unload_material(&self.thread, material) }
+    }
+
+    pub fn unload_model(&mut self, _: &RaylibThread, model: WeakModel) {
+        unsafe { self.rl.unload_model(&self.thread, model) }
+    }
+
+    pub fn unload_model_animation(
+        &mut self,
+        _: &RaylibThread,
+        model_animation: WeakModelAnimation,
+    ) {
+        unsafe {
+            self.rl
+                .unload_model_animation(&self.thread, model_animation)
+        }
+    }
+
+    pub fn unload_mesh(&mut self, _: &RaylibThread, mesh: WeakMesh) {
+        unsafe { self.rl.unload_mesh(&self.thread, mesh) }
+    }
+
+    pub fn load_shader(
+        &mut self,
+        _: &RaylibThread,
+        vs_filename: Option<&str>,
+        fs_filename: Option<&str>,
+    ) -> Shader {
+        self.rl.load_shader(&self.thread, vs_filename, fs_filename)
+    }
+
+    pub fn load_shader_from_memory(
+        &mut self,
+        _: &RaylibThread,
+        vs_code: Option<&str>,
+        fs_code: Option<&str>,
+    ) -> Shader {
+        self.rl
+            .load_shader_from_memory(&self.thread, vs_code, fs_code)
+    }
+
+    pub fn load_font(&mut self, _: &RaylibThread, filename: &str) -> Result<Font, Error> {
+        self.rl.load_font(&self.thread, filename)
+    }
+
+    pub fn load_font_ex(
+        &mut self,
+        _: &RaylibThread,
+        filename: &str,
+        font_size: i32,
+        chars: Option<&str>,
+    ) -> Result<Font, Error> {
+        self.rl
+            .load_font_ex(&self.thread, filename, font_size, chars)
+    }
+
+    pub fn load_font_from_image(
+        &mut self,
+        _: &RaylibThread,
+        image: &Image,
+        key: impl Into<raylib::ffi::Color>,
+        first_char: i32,
+    ) -> Result<Font, Error> {
+        self.rl
+            .load_font_from_image(&self.thread, image, key, first_char)
+    }
+
+    pub fn load_font_from_memory(
+        &mut self,
+        _: &RaylibThread,
+        file_type: &str,
+        file_data: &[u8],
+        font_size: i32,
+        chars: Option<&str>,
+    ) -> Result<Font, Error> {
+        self.rl
+            .load_font_from_memory(&self.thread, file_type, file_data, font_size, chars)
+    }
+
+    pub fn load_texture(&mut self, _: &RaylibThread, filename: &str) -> Result<Texture2D, Error> {
+        self.rl.load_texture(&self.thread, filename)
+    }
+
+    pub fn load_texture_cubemap(
+        &mut self,
+        _: &RaylibThread,
+        image: &Image,
+        layout: CubemapLayout,
+    ) -> Result<Texture2D, Error> {
+        self.rl.load_texture_cubemap(&self.thread, image, layout)
+    }
+
+    pub fn load_texture_from_image(
+        &mut self,
+        _: &RaylibThread,
+        image: &Image,
+    ) -> Result<Texture2D, Error> {
+        self.rl.load_texture_from_image(&self.thread, image)
+    }
+
+    pub fn load_render_texture(
+        &mut self,
+        _: &RaylibThread,
+        width: u32,
+        height: u32,
+    ) -> Result<RenderTexture2D, Error> {
+        self.rl.load_render_texture(&self.thread, width, height)
+    }
+
+    pub fn unload_texture(&mut self, _: &RaylibThread, texture: WeakTexture2D) {
+        unsafe { self.rl.unload_texture(&self.thread, texture) }
+    }
+    pub fn unload_render_texture(&mut self, _: &RaylibThread, texture: WeakRenderTexture2D) {
+        unsafe { self.rl.unload_render_texture(&self.thread, texture) }
+    }
+    pub fn load_vr_stereo_config(
+        &mut self,
+        _: &RaylibThread,
+        device: impl Into<raylib::ffi::VrDeviceInfo>,
+    ) -> VrStereoConfig {
+        self.rl.load_vr_stereo_config(&self.thread, device)
+    }
+
+    pub fn set_window_title(&self, _: &RaylibThread, title: &str) {
+        self.rl.set_window_title(&self.thread, title)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,11 @@
 //! A Raylib plugin for bevy.
-#![expect(missing_docs, reason="Docmentation isn't written (yet)")]
+#![expect(missing_docs, reason = "Docmentation isn't written (yet)")]
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use raylib::prelude::*;
+
+mod context;
+pub use context::RaylibContext;
 
 pub mod prelude {
     pub use crate::{Cursor, RaylibContext, RaylibPlugin, WindowConfig};
@@ -50,17 +53,6 @@ pub fn update_cursor(raylib_context: NonSend<RaylibContext>, mut cursor: ResMut<
     *cursor = {
         let Vector2 { x, y } = raylib_context.rl.get_mouse_position();
         Cursor { x, y }
-    }
-}
-
-pub struct RaylibContext {
-    pub rl: RaylibHandle,
-    thread: RaylibThread,
-}
-
-impl RaylibContext {
-    pub fn begin_drawing(&mut self) -> RaylibDrawHandle {
-        self.rl.begin_drawing(&self.thread)
     }
 }
 


### PR DESCRIPTION
### Description
 - Add wrappers for methods that use `RaylibThread` in `impl RaylibContext`
 - Move `RaylibContext` to `context.rs`
### Checklist
- [x] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
